### PR TITLE
Attempt on FreeBSD support

### DIFF
--- a/main.c
+++ b/main.c
@@ -568,7 +568,8 @@ static void cc1(void) {
 }
 
 static void assemble(char *input, char *output) {
-  char *cmd[] = {"as", "-c", input, "-o", output, NULL};
+  // FIXME this would break other platforms, need detection
+  char *cmd[] = {"as",  input, "-o", output, NULL};
   run_subprocess(cmd);
 }
 
@@ -593,6 +594,8 @@ static char *find_libpath(void) {
     return "/usr/lib/x86_64-linux-gnu";
   if (file_exists("/usr/lib64/crti.o"))
     return "/usr/lib64";
+  if (file_exists("/usr/lib/crti.o"))
+    return "/usr/lib";
   error("library path is not found");
 }
 
@@ -601,6 +604,7 @@ static char *find_gcc_libpath(void) {
     "/usr/lib/gcc/x86_64-linux-gnu/*/crtbegin.o",
     "/usr/lib/gcc/x86_64-pc-linux-gnu/*/crtbegin.o", // For Gentoo
     "/usr/lib/gcc/x86_64-redhat-linux/*/crtbegin.o", // For Fedora
+    "/usr/lib/crtbegin.o", // FreeBSD
   };
 
   for (int i = 0; i < sizeof(paths) / sizeof(*paths); i++) {


### PR DESCRIPTION
Check FreeBSD-specific library locations, and update `as` command line. This is not a complete solution as latter would not work on other platforms, and dynamic linking still would not be supported. However, with this change, it is possible to create a statically-linked executable on FreeBSD, as long as #21 is avoided.