### PR TITLE
Binary add segfaults when at least 1 arg is non-numeric, and both are non-pointer types

### DIFF
--- a/parse.c
+++ b/parse.c
@@ -2355,11 +2355,12 @@ static Node *new_add(Node *lhs, Node *rhs, Token *tok) {
   if (is_numeric(lhs->ty) && is_numeric(rhs->ty))
     return new_binary(ND_ADD, lhs, rhs, tok);
 
-  if (lhs->ty->base && rhs->ty->base)
+  if ((lhs->ty->base == NULL && rhs->ty->base == NULL) ||
+      (lhs->ty->base != NULL && rhs->ty->base != NULL))
     error_tok(tok, "invalid operands");
 
   // Canonicalize `num + ptr` to `ptr + num`.
-  if (!lhs->ty->base && rhs->ty->base) {
+  if (lhs->ty->base == NULL && rhs->ty->base != NULL) {
     Node *tmp = lhs;
     lhs = rhs;
     rhs = tmp;


### PR DESCRIPTION
## Problem

The following program segfaults in `new_add` function from `parse.c`

```c
void foo() { }

void bar() {
  1 + foo();
}
```

## Proposal

Check for the case when both args are non-pointer types; check `NULL` explicitly to improve readability.

Note the following program still compiles with or without this patch:

```c
void foo() { }

void bar() {
  int *a;
  a + foo();
}
```

It could be fixed easily, but like mentioned in #41, a separate "typecheck" phase would probably be a better solution IMHO.
