### PR TITLE
It's UB to have a call to va_start without a corresponding call to va_end

### DIFF
--- a/tokenize.c
+++ b/tokenize.c
@@ -17,6 +17,7 @@ void error(char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
   vfprintf(stderr, fmt, ap);
+  va_end(ap);
   fprintf(stderr, "\n");
   exit(1);
 }
@@ -58,6 +59,7 @@ void error_at(char *loc, char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
   verror_at(current_file->name, current_file->contents, line_no, loc, fmt, ap);
+  va_end(ap);
   exit(1);
 }
 
@@ -65,6 +67,7 @@ void error_tok(Token *tok, char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
   verror_at(tok->file->name, tok->file->contents, tok->line_no, tok->loc, fmt, ap);
+  va_end(ap);
   exit(1);
 }
 


### PR DESCRIPTION
This is just a tiny nitpick, but Annex J says:

> The behavior is undefined in the following circumstances: [...] The va_start or va_copy macro is invoked without a corresponding invocation of the va_end macro in the same function, or vice versa

So its technically UB, even if you call `exit()`. This will probably not cause any problems, but it might be worth having the code be more compliant.

(Also thanks for the amazing project!)
