### PR TITLE
Remove duplicate struct tests

### DIFF
--- a/test/struct.c
+++ b/test/struct.c
@@ -41,11 +41,6 @@ int main() {
   ASSERT(7, ({ struct t {int a,b;}; struct t x; x.a=7; struct t y, *p=&x, *q=&y; *q=*p; y.a; }));
   ASSERT(5, ({ struct t {char a, b;} x, y; x.a=5; y=x; y.a; }));
 
-  ASSERT(3, ({ struct {int a,b;} x,y; x.a=3; y=x; y.a; }));
-  ASSERT(7, ({ struct t {int a,b;}; struct t x; x.a=7; struct t y; struct t *z=&y; *z=x; y.a; }));
-  ASSERT(7, ({ struct t {int a,b;}; struct t x; x.a=7; struct t y, *p=&x, *q=&y; *q=*p; y.a; }));
-  ASSERT(5, ({ struct t {char a, b;} x, y; x.a=5; y=x; y.a; }));
-
   ASSERT(8, ({ struct t {int a; int b;} x; struct t y; sizeof(y); }));
   ASSERT(8, ({ struct t {int a; int b;}; struct t y; sizeof(y); }));
 


### PR DESCRIPTION
Trivial PR to remove duplicate struct tests (same group of tests done twice - probably a copy-paste)