### PR TITLE
Hashmap: Do not insert duplicate keys

### DIFF
--- a/hashmap.c
+++ b/hashmap.c
@@ -23,7 +23,7 @@ static uint64_t fnv_hash(char *s, int len) {
   return hash;
 }
 
-// Make room for new entires in a given hashmap by removing
+// Make room for new entries in a given hashmap by removing
 // tombstones and possibly extending the bucket size.
 static void rehash(HashMap *map) {
   // Compute the size of the new hashmap.
@@ -89,11 +89,6 @@ static HashEntry *get_or_insert_entry(HashMap *map, char *key, int keylen) {
     if (match(ent, key, keylen))
       return ent;
 
-    if (ent->key == TOMBSTONE) {
-      ent->key = key;
-      ent->keylen = keylen;
-      return ent;
-    }
 
     if (ent->key == NULL) {
       ent->key = key;


### PR DESCRIPTION
**Description**
While looking into the table for a spot for the new key, search
until an empty one is found and do not overwrite tombstones.

**Reported as** #53.

**Test**

I was not able to find FNV colliding strings so instead I replaced the hash function and used a "dumb" one instead:
```
static uint64_t dumb_hash(char *s, int len) {
    if (len < 5)
        return 0;
    return 1;
}
```

Then using the following test case I reproduced the issue:
```
  hashmap_put(map, "123", (void *)(size_t)3);
  hashmap_put(map, "345", (void *)(size_t)3);
  assert(hashmap_get(map, "123") == (void *)(size_t) 3);
  assert(hashmap_get(map, "345") == (void *)(size_t) 3);
  hashmap_delete(map, "123");
  hashmap_put(map, "345", (void *)(size_t)3);
  assert(hashmap_get(map, "345") == (void *)(size_t) 3);
  hashmap_delete(map, "345");
  assert(hashmap_get(map, "345") == (void *)(size_t) 3);
```

The test passes when using 2c523f.

Signed-off-by: Kristiyan Stoimenov <kristoimenov@gmail.com>