### PR TITLE
Fix atomic fetch operations

### DIFF
--- a/chibicc.h
+++ b/chibicc.h
@@ -282,6 +282,9 @@ struct Node {
   Obj *atomic_addr;
   Node *atomic_expr;
 
+  // Atomic fetch operation
+  bool atomic_fetch;
+
   // Variable
   Obj *var;
 

--- a/include/stdatomic.h
+++ b/include/stdatomic.h
@@ -34,17 +34,17 @@ typedef enum {
 #define atomic_load_explicit(addr, order) (*(addr))
 #define atomic_store_explicit(addr, val, order) (*(addr) = (val))
 
-#define atomic_fetch_add(obj, val) (*(obj) += (val))
-#define atomic_fetch_sub(obj, val) (*(obj) -= (val))
-#define atomic_fetch_or(obj, val) (*(obj) |= (val))
-#define atomic_fetch_xor(obj, val) (*(obj) ^= (val))
-#define atomic_fetch_and(obj, val) (*(obj) &= (val))
+#define atomic_fetch_add(obj, val) __builtin_atomic_fetch_op(obj, val, 0)
+#define atomic_fetch_sub(obj, val) __builtin_atomic_fetch_op(obj, val, 1)
+#define atomic_fetch_or(obj, val) __builtin_atomic_fetch_op(obj, val, 2)
+#define atomic_fetch_xor(obj, val) __builtin_atomic_fetch_op(obj, val, 3)
+#define atomic_fetch_and(obj, val) __builtin_atomic_fetch_op(obj, val, 4)
 
-#define atomic_fetch_add_explicit(obj, val, order) (*(obj) += (val))
-#define atomic_fetch_sub_explicit(obj, val, order) (*(obj) -= (val))
-#define atomic_fetch_or_explicit(obj, val, order) (*(obj) |= (val))
-#define atomic_fetch_xor_explicit(obj, val, order) (*(obj) ^= (val))
-#define atomic_fetch_and_explicit(obj, val, order) (*(obj) &= (val))
+#define atomic_fetch_add_explicit(obj, val, order) atomic_fetch_add(obj, val)
+#define atomic_fetch_sub_explicit(obj, val, order) atomic_fetch_sub(obj, val)
+#define atomic_fetch_or_explicit(obj, val, order) atomic_fetch_or(obj, val)
+#define atomic_fetch_xor_explicit(obj, val, order) atomic_fetch_xor(obj, val)
+#define atomic_fetch_and_explicit(obj, val, order) atomic_fetch_and(obj, val)
 
 #define atomic_compare_exchange_weak(p, old, new) \
   __builtin_compare_and_swap((p), (old), (new))

--- a/test/atomic.c
+++ b/test/atomic.c
@@ -52,11 +52,29 @@ static int add_millions(void) {
   return x;
 }
 
+static void fetch_ops(void) {
+  _Atomic int x = 0;
+
+  ASSERT(0, atomic_fetch_add(&x, 17));
+  ASSERT(17, atomic_fetch_add(&x, 10));
+  ASSERT(27, atomic_fetch_add(&x, 3));
+  ASSERT(30, atomic_fetch_sub(&x, 17));
+  ASSERT(13, atomic_fetch_sub(&x, 13));
+
+  ASSERT(0, atomic_fetch_or(&x, 0xf0));
+  ASSERT(0xf0, atomic_fetch_or(&x, 0x0f));
+  ASSERT(0xff, atomic_fetch_and(&x, 0x0f));
+  ASSERT(0x0f, atomic_fetch_xor(&x, 0xff));
+  ASSERT(0xf0, atomic_fetch_add(&x, 0));
+}
+
 int main() {
   ASSERT(6*1000*1000, add_millions());
 
   ASSERT(3, ({ int x=3; atomic_exchange(&x, 5); }));
   ASSERT(5, ({ int x=3; atomic_exchange(&x, 5); x; }));
+
+  fetch_ops();
 
   printf("OK\n");
   return 0;


### PR DESCRIPTION
The atomic_fetch ops are supposed to return the old value of the object. chibicc is currently returning the new values.

stdatomic.h:

``` c
#define atomic_fetch_add(obj, val) (*(obj) += (val))
#define atomic_fetch_sub(obj, val) (*(obj) -= (val))
#define atomic_fetch_or(obj, val) (*(obj) |= (val))
#define atomic_fetch_xor(obj, val) (*(obj) ^= (val))
#define atomic_fetch_and(obj, val) (*(obj) &= (val))
```

I was originally thinking about how to fix this in a simple way. Three of them (add/sub/xor) are fixable with macros. Something like:

``` c
#define atomic_fetch_add(obj, val) ({ \
  typeof(val) _val = (val);           \
  ((*(obj) += _val) - _val);          \
})

#define atomic_fetch_sub(obj, val) ({ \
  typeof(val) _val = (val);           \
  ((*(obj) -= _val) + _val);          \
})

#define atomic_fetch_xor(obj, val) ({ \
  typeof(val) _val = (val);           \
  ((*(obj) ^= _val) ^ _val);          \
})
```

However, `atomic_fetch_and` and `atomic_fetch_or` are not fixable via macro as they are not reversible.

This PR adds a single new builtin (`__builtin_atomic_fetch_op`) which reuses the existing atomic operation code.