### PR TITLE
Fix dependency generation

### DIFF
--- a/main.c
+++ b/main.c
@@ -365,7 +365,7 @@ static bool endswith(char *p, char *q) {
 
 // Replace file extension
 static char *replace_extn(char *tmpl, char *extn) {
-  char *filename = basename(strdup(tmpl));
+  char *filename = strdup(tmpl);
   char *dot = strrchr(filename, '.');
   if (dot)
     *dot = '\0';
@@ -459,11 +459,13 @@ static bool in_std_include_path(char *path) {
 // stdout in a format that "make" command can read. This feature is
 // used to automate file dependency management.
 static void print_dependencies(void) {
+  char *name = opt_o ? opt_o : base_file;
+
   char *path;
   if (opt_MF)
     path = opt_MF;
   else if (opt_MD)
-    path = replace_extn(opt_o ? opt_o : base_file, ".d");
+    path = replace_extn(name, ".d");
   else if (opt_o)
     path = opt_o;
   else
@@ -473,7 +475,7 @@ static void print_dependencies(void) {
   if (opt_MT)
     fprintf(out, "%s:", opt_MT);
   else
-    fprintf(out, "%s:", quote_makefile(replace_extn(base_file, ".o")));
+    fprintf(out, "%s:", quote_makefile(replace_extn(name, ".o")));
 
   File **files = get_input_files();
 
@@ -731,13 +733,15 @@ int main(int argc, char **argv) {
       continue;
     }
 
+    char *input_base = basename(strdup(input));
+
     char *output;
     if (opt_o)
       output = opt_o;
     else if (opt_S)
-      output = replace_extn(input, ".s");
+      output = replace_extn(input_base, ".s");
     else
-      output = replace_extn(input, ".o");
+      output = replace_extn(input_base, ".o");
 
     FileType type = get_file_type(input);
 

--- a/test/driver.sh
+++ b/test/driver.sh
@@ -225,12 +225,12 @@ check 'hashmap'
 echo '#include "out2.h"' > $tmp/out.c
 echo '#include "out3.h"' >> $tmp/out.c
 touch $tmp/out2.h $tmp/out3.h
-$chibicc -M -I$tmp $tmp/out.c | grep -q -z '^out.o: .*/out\.c .*/out2\.h .*/out3\.h'
+$chibicc -M -I$tmp $tmp/out.c | grep -q -z '^.*/out.o: .*/out\.c .*/out2\.h .*/out3\.h'
 check -M
 
 # -MF
 $chibicc -MF $tmp/mf -M -I$tmp $tmp/out.c
-grep -q -z '^out.o: .*/out\.c .*/out2\.h .*/out3\.h' $tmp/mf
+grep -q -z '^.*/out.o: .*/out\.c .*/out2\.h .*/out3\.h' $tmp/mf
 check -MF
 
 # -MP
@@ -256,7 +256,7 @@ grep -q -z '^md3.o:.* md3\.c .* ./out3\.h' $tmp/md3.d
 check -MD
 
 $chibicc -c -MD -MF $tmp/md-mf.d -I. $tmp/md2.c
-grep -q -z '^md2.o:.*md2\.c .*/out2\.h' $tmp/md-mf.d
+grep -q -z '^.*/md2.o:.*md2\.c .*/out2\.h' $tmp/md-mf.d
 check -MD
 
 echo 'extern int bar; int foo() { return bar; }' | $chibicc -fPIC -xc -c -o $tmp/foo.o -


### PR DESCRIPTION
Dependencies generated with -MD are always generated relative to the current directory, instead of being stored in the target directory. This solves that issue.