### PR TITLE
fix assembler error on large files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,12 @@ test-stage2: $(TESTS:test/%=stage2/test/%)
 
 # Misc.
 
+install:
+	test -d /usr/local/include/x86_64-linux-gnu/chibicc || \
+		sudo mkdir -p /usr/local/include/x86_64-linux-gnu/chibicc
+	sudo cp include/* /usr/local/include/x86_64-linux-gnu/chibicc/
+	sudo cp chibicc /usr/local/bin/chibicc
+
 clean:
 	rm -rf chibicc tmp* $(TESTS) test/*.s test/*.exe stage2
 	find * -type f '(' -name '*~' -o -name '*.o' ')' -exec rm {} ';'

--- a/chibicc.h
+++ b/chibicc.h
@@ -61,7 +61,7 @@ typedef enum {
 
 typedef struct {
   char *name;
-  int file_no;
+  unsigned file_no;
   char *contents;
 
   // For #line directive
@@ -83,7 +83,7 @@ struct Token {
 
   File *file;       // Source location
   char *filename;   // Filename
-  int line_no;      // Line number
+  unsigned line_no; // Line number
   int line_delta;   // Line number
   bool at_bol;      // True if this token is at beginning of line
   bool has_space;   // True if this token follows a space character
@@ -100,13 +100,13 @@ Token *skip(Token *tok, char *op);
 bool consume(Token **rest, Token *tok, char *str);
 void convert_pp_tokens(Token *tok);
 File **get_input_files(void);
-File *new_file(char *name, int file_no, char *contents);
+File *new_file(char *name, unsigned file_no, char *contents);
 Token *tokenize_string_literal(Token *tok, Type *basety);
 Token *tokenize(File *file);
 Token *tokenize_file(char *filename);
 
 #define unreachable() \
-  error("internal error at %s:%d", __FILE__, __LINE__)
+  error("internal error at %s:%u", __FILE__, __LINE__)
 
 //
 // preprocess.c

--- a/codegen.c
+++ b/codegen.c
@@ -690,7 +690,7 @@ static void builtin_alloca(void) {
 
 // Generate code for a given node.
 static void gen_expr(Node *node) {
-  println("  .loc %d %d", node->tok->file->file_no, node->tok->line_no);
+  println("  .loc %u %u", node->tok->file->file_no, node->tok->line_no);
 
   switch (node->kind) {
   case ND_NULL_EXPR:
@@ -1186,7 +1186,7 @@ static void gen_expr(Node *node) {
 }
 
 static void gen_stmt(Node *node) {
-  println("  .loc %d %d", node->tok->file->file_no, node->tok->line_no);
+  println("  .loc %u %u", node->tok->file->file_no, node->tok->line_no);
 
   switch (node->kind) {
   case ND_IF: {

--- a/main.c
+++ b/main.c
@@ -691,7 +691,8 @@ static FileType get_file_type(char *filename) {
     return FILE_OBJ;
   if (endswith(filename, ".c"))
     return FILE_C;
-  if (endswith(filename, ".s"))
+  if (endswith(filename, ".s") || endswith(filename, ".S") ||
+      endswith(filename, ".asm"))
     return FILE_ASM;
 
   error("<command line>: unknown file extension: %s", filename);
@@ -747,7 +748,7 @@ int main(int argc, char **argv) {
       continue;
     }
 
-    // Handle .s
+    // Handle .s, -S, .asm
     if (type == FILE_ASM) {
       if (!opt_S)
         assemble(input, output);

--- a/main.c
+++ b/main.c
@@ -57,6 +57,7 @@ static void add_default_include_paths(char *argv0) {
 
   // Add standard include paths.
   strarray_push(&include_paths, "/usr/local/include");
+  strarray_push(&include_paths, "/usr/local/include/x86_64-linux-gnu/chibicc");
   strarray_push(&include_paths, "/usr/include/x86_64-linux-gnu");
   strarray_push(&include_paths, "/usr/include");
 

--- a/tokenize.c
+++ b/tokenize.c
@@ -25,7 +25,7 @@ void error(char *fmt, ...) {
 //
 // foo.c:10: x = y + 1;
 //               ^ <error message here>
-static void verror_at(char *filename, char *input, int line_no,
+static void verror_at(char *filename, char *input, unsigned line_no,
                       char *loc, char *fmt, va_list ap) {
   // Find a line containing `loc`.
   char *line = loc;
@@ -37,7 +37,7 @@ static void verror_at(char *filename, char *input, int line_no,
     end++;
 
   // Print out the line.
-  int indent = fprintf(stderr, "%s:%d: ", filename, line_no);
+  int indent = fprintf(stderr, "%s:%u: ", filename, line_no);
   fprintf(stderr, "%.*s\n", (int)(end - line), line);
 
   // Show the error message.
@@ -50,7 +50,7 @@ static void verror_at(char *filename, char *input, int line_no,
 }
 
 void error_at(char *loc, char *fmt, ...) {
-  int line_no = 1;
+  unsigned line_no = 1;
   for (char *p = current_file->contents; p < loc; p++)
     if (*p == '\n')
       line_no++;
@@ -678,7 +678,7 @@ File **get_input_files(void) {
   return input_files;
 }
 
-File *new_file(char *name, int file_no, char *contents) {
+File *new_file(char *name, unsigned file_no, char *contents) {
   File *file = calloc(1, sizeof(File));
   file->name = name;
   file->display_name = name;
@@ -792,7 +792,7 @@ Token *tokenize_file(char *path) {
   convert_universal_chars(p);
 
   // Save the filename for assembler .file directive.
-  static int file_no;
+  static unsigned file_no;
   File *file = new_file(path, file_no + 1, p);
 
   // Save the filename for assembler .file directive.


### PR DESCRIPTION
the line_no must be unsigned.
.loc N -NUM is invalid, leading to "Error: file number less than one." Ditto for file_no

it's a small compiler, but my generated .s file has still 518904 lines

oh, forgot: I added "/usr/local/include/x86_64-linux-gnu/chibicc" to the -I path, because I copied your headers there.