### PR TITLE
Allow modulus in constant expressions

### DIFF
--- a/parse.c
+++ b/parse.c
@@ -1954,6 +1954,7 @@ static bool is_const_expr(Node *node) {
   case ND_SUB:
   case ND_MUL:
   case ND_DIV:
+  case ND_MOD:
   case ND_BITAND:
   case ND_BITOR:
   case ND_BITXOR:


### PR DESCRIPTION
Not sure if this was intentional, but I noticed `eval2(...)` will compile-time evaluate a modulus but `is_const_expr(...)` won't. This causes chibicc to try and compile some arrays as VLAs, which was causing problems for me. This change adds `ND_MOD` to the list of allowed constant expressions.

It's possible I'm missing something, but https://en.cppreference.com/w/c/language/constant_expression seems to imply that all numeric operators (including modulus) should be OK in constant expressions. And `ND_DIV` is already allowed in the function so it seems `ND_MOD` should be as well.