### PR TITLE
make struct size the sum of sizes of all members

### DIFF
--- a/parse.c
+++ b/parse.c
@@ -1300,10 +1300,11 @@ static Initializer *initializer(Token **rest, Token *tok, Type *ty, Type **new_t
     ty = copy_struct_type(ty);
 
     Member *mem = ty->members;
-    while (mem->next)
+    while (mem->next) {
       mem = mem->next;
-    mem->ty = init->children[mem->idx]->ty;
-    ty->size += mem->ty->size;
+      mem->ty = init->children[mem->idx]->ty;
+      ty->size += mem->ty->size;
+    }
 
     *new_ty = ty;
     return init;


### PR DESCRIPTION
I am unsure about this code, but the += seemed
a bit fishy, so I assume the code for determining
struct size should be summing up the sizes of all
struct members, rather than the size of the final
member.