### PR TITLE
func_params token skip refactor

### DIFF
--- a/parse.c
+++ b/parse.c
@@ -598,7 +598,6 @@ static Type *func_params(Token **rest, Token *tok, Type *ty) {
     if (equal(tok, "...")) {
       is_variadic = true;
       tok = tok->next;
-      skip(tok, ")");
       break;
     }
 
@@ -628,7 +627,7 @@ static Type *func_params(Token **rest, Token *tok, Type *ty) {
   ty = func_type(ty);
   ty->params = head.next;
   ty->is_variadic = is_variadic;
-  *rest = tok->next;
+  *rest = skip(tok, ")");
   return ty;
 }
 


### PR DESCRIPTION
In func_params, the branch for handling "..." calls skip(tok, ")"), which triggered a bug in my rewrite.
After careful inspection, I realize the return value is not being used, so there is no bug.
Nevertheless, it may still be worth it to move the skip to the bottom of the function.