### PR TITLE
Fix segfault (null deref) in named initialisation of nested anonymous union

### DIFF
--- a/parse.c
+++ b/parse.c
@@ -1003,10 +1003,11 @@ static Member *struct_designator(Token **rest, Token *tok, Type *ty) {
 
   for (Member *mem = ty->members; mem; mem = mem->next) {
     // Anonymous struct member
-    if (mem->ty->kind == TY_STRUCT && !mem->name) {
-      if (get_struct_member(mem->ty, tok)) {
-        *rest = start;
-        return mem;
+    if (!mem->name) {
+      if ((mem->ty->kind == TY_STRUCT || mem->ty->kind == TY_UNION)
+          && get_struct_member(mem->ty, tok)) {
+          *rest = start;
+          return mem;
       }
       continue;
     }
@@ -2736,11 +2737,13 @@ static Type *union_decl(Token **rest, Token *tok) {
 
 // Find a struct member by name.
 static Member *get_struct_member(Type *ty, Token *tok) {
+  assert(ty->kind == TY_STRUCT || ty->kind == TY_UNION);
+
   for (Member *mem = ty->members; mem; mem = mem->next) {
     // Anonymous struct member
-    if ((mem->ty->kind == TY_STRUCT || mem->ty->kind == TY_UNION) &&
-        !mem->name) {
-      if (get_struct_member(mem->ty, tok))
+    if (!mem->name) {
+      if ((mem->ty->kind == TY_STRUCT || mem->ty->kind == TY_UNION) &&
+          get_struct_member(mem->ty, tok))
         return mem;
       continue;
     }

--- a/test/anon-union-init.c
+++ b/test/anon-union-init.c
@@ -1,0 +1,20 @@
+#include "test.h"
+
+struct foo {
+  int simple;
+  int : 7;
+  union {
+    int anon;
+    union tagged {
+      float qux;
+      long baz;
+    } named;
+  };
+};
+
+struct foo bar = { .simple = 1, .named.qux = 1.0 };
+
+int main() {
+  printf("OK\n");
+  return 0;
+}


### PR DESCRIPTION
This seems very specific but I did happen upon it organically. What were the chances? lol

Also adds a regression test, which causes previous chibicc version to deref NULL and segfault (the cc1 process dies with SIGSEGV, which causes the driver to `exit(1)`).

I think I'm right to assume that the only way `mem->name` can be NULL is if `mem` is an anonymous union/struct? Just wanted to make sure