### PR TITLE
reported conditional operator semantic error

### DIFF
--- a/parse.c
+++ b/parse.c
@@ -2207,6 +2207,8 @@ static Node *conditional(Token **rest, Token *tok) {
   node->cond = cond;
   node->then = expr(&tok, tok->next);
   tok = skip(tok, ":");
+  if (tok->at_bol)
+    error_tok(tok, "expected an expression");
   node->els = conditional(rest, tok);
   return node;
 }

--- a/tokenize.c
+++ b/tokenize.c
@@ -77,7 +77,7 @@ void warn_tok(Token *tok, char *fmt, ...) {
 
 // Consumes the current token if it matches `op`.
 bool equal(Token *tok, char *op) {
-  return memcmp(tok->loc, op, tok->len) == 0 && op[tok->len] == '\0';
+  return strlen(op) == tok->len && strncmp(tok->loc, op, tok->len) == 0;
 }
 
 // Ensure that the current token is `op`.


### PR DESCRIPTION
> The first operand is evaluated; there is a sequence point between its evaluation and the evaluation of the second or third operand (whichever is evaluated). 

simple fix, reported violates the mandatory requirement that the conditional operator must have three operands.